### PR TITLE
Disable missile launch until location is locked

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,7 +35,7 @@
     <button id="btnLocate" class="btn neon">▶ Obtener ubicación</button>
     <button id="btnCopy" class="btn">⎘ Copiar coords</button>
     <button id="btnClear" class="btn">✖ Limpiar</button>
-    <button id="btnBoom" class="btn danger strong">🚀 DISPARAR MISIL</button>
+    <button id="btnBoom" class="btn danger strong" disabled>🚀 DISPARAR MISIL</button>
   </div>
 
   <div id="map" class="panel" aria-label="Mapa con tu ubicación"></div>

--- a/script.js
+++ b/script.js
@@ -9,6 +9,8 @@ const btnCopy = document.getElementById('btnCopy');
 const btnClear = document.getElementById('btnClear');
 const btnBoom = document.getElementById('btnBoom');
 const explosionRoot = document.getElementById('explosion-root');
+// missile button disabled until location acquired
+btnBoom.disabled = true;
 
 // Init world view
 const map = L.map(mapEl).setView([0, 0], 2);
@@ -19,6 +21,7 @@ L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
 
 let marker = null;
 let accuracyCircle = null;
+let locationAcquired = false;
 
 function writeStatus(lines) {
   if (Array.isArray(lines)) { statusEl.textContent = lines.join('\n'); }
@@ -47,6 +50,8 @@ function clearMarker() {
   if (accuracyCircle) { map.removeLayer(accuracyCircle); accuracyCircle = null; }
   updateInfoPlaceholders();
   writeStatus('[OK] Buffer limpiado.');
+  locationAcquired = false;
+  btnBoom.disabled = true;
 }
 
 function placeMarker(lat, lng, acc) {
@@ -62,6 +67,8 @@ function placeMarker(lat, lng, acc) {
   marker.bindPopup('TARGET LOCKED').openPopup();
   updateInfo(lat, lng, acc);
   map.flyTo([lat, lng], 16, { duration: 0.75 });
+  locationAcquired = true;
+  btnBoom.disabled = false;
 }
 
 // Fancy locate flow

--- a/style.css
+++ b/style.css
@@ -79,6 +79,11 @@ header.panel p { margin: 0; color: var(--muted); }
 .btn:hover { background: rgba(25,255,140,.12); transform: translateY(-1px); }
 .btn:active { transform: translateY(0); }
 .btn.neon { box-shadow: 0 0 18px rgba(25,255,140,.25), inset 0 1px 0 rgba(255,255,255,.08); }
+.btn:disabled {
+  opacity: .5;
+  cursor: not-allowed;
+  filter: grayscale(0.6);
+}
 .btn.danger {
   background: linear-gradient(180deg, rgba(255, 59, 59, .15), rgba(120, 0, 0, .25));
   border-color: rgba(255,59,59,.6);


### PR DESCRIPTION
## Summary
- Disable "DISPARAR MISIL" button by default and toggle based on location acquisition
- Track location lock state and block missile launch until coords exist
- Style disabled buttons for clearer UX

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689cf5bcef20832187ebf85bdf79e49a